### PR TITLE
EPS-814: Wordpress 6.7 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pratikchaskar
 Requires at least: 4.4
 Tags: beaver builder, page builder plugin, column, separator, column separator, style, simple column
 Stable tag: 1.0.2
-Tested up to: 6.6
+Tested up to: 6.7
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This pull request includes a minor update to the `readme.txt` file to reflect the latest tested WordPress version.

* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6): Updated the `Tested up to` field from version 6.6 to 6.7.