### PR TITLE
EPS-1184: Wordpress 6.8 compatibility for Column separator for BB

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pratikchaskar
 Requires at least: 4.4
 Tags: beaver builder, page builder plugin, column separator, style, simple column
 Stable tag: 1.0.2
-Tested up to: 6.7
+Tested up to: 6.8
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This pull request includes a minor update to the readme.txt file to reflect the latest tested WordPress version.